### PR TITLE
Fix nullable ref schema (#509)

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1664,11 +1664,11 @@ impl ToTokens for SchemaProperty<'_> {
                                     name = Cow::Borrowed(self.object_name);
                                 }
                                 nullable
-                                    .map(|_| {
+                                    .map(|nullable| {
                                         quote! {
                                             utoipa::openapi::schema::AllOfBuilder::new()
+                                                #nullable
                                                 .item(utoipa::openapi::Ref::from_schema_name(#name))
-                                                .item(utoipa::openapi::schema::Object::nullable())
                                         }
                                     })
                                     .unwrap_or_else(|| {

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -238,7 +238,8 @@ fn derive_struct_with_optional_properties() {
             id: u64,
             enabled: Option<bool>,
             books: Option<Vec<Book>>,
-            metadata: Option<HashMap<String, String>>
+            metadata: Option<HashMap<String, String>>,
+            optional_book: Option<Book>
         }
     };
 
@@ -269,12 +270,21 @@ fn derive_struct_with_optional_properties() {
                         "type": "string"
                     }
                 },
+                "optional_book": {
+                    "nullable": true,
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/Book"
+                        }
+                    ]
+                }
             },
             "required": [
                 "id",
                 "enabled",
                 "books",
                 "metadata",
+                "optional_book"
             ],
             "type": "object"
         })


### PR DESCRIPTION
This commit adds support for correct $ref schema nullable fields. Optioal type field e.g. `book: Option<Book>` will be rendered as nullable allOf field so client side generators can create correct client and types from the generated openapi.json.
```json
 "book": {
     "nullable": true,
     "allOf": [
         {
             "$ref": "#/components/schemas/Book"
         }
     ]
 }
```